### PR TITLE
Declare Dune modes for executable

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,5 @@
 (executable
  (name gatorc)
+ (modes exe byte js)
  (public_name gatorc)
  (libraries gatorl))


### PR DESCRIPTION
I'm not sure if this is a Dune version difference or something, but my Dune (2.5.1) required me to put this `modes` thing into allow building `gatorc.bc.js`. Otherwise, it only worked to build `gatorc.exe`.
