### PR TITLE
Subtype of parameterized

### DIFF
--- a/src/check.ml
+++ b/src/check.ml
@@ -1044,6 +1044,9 @@ let check_typ_decl (cx : contexts) (x : string) ((b, pm, t) : tau) : contexts =
     match t with
     | AnyTyp | BoolTyp | IntTyp | FloatTyp | StringTyp -> t
     | ArrTyp (t', _) -> check_valid_supertype t'
+    | MemberTyp (mem_c, mem_t) -> 
+        check_valid_supertype mem_c |> ignore_typ;
+        check_valid_supertype mem_t
     | ParTyp (s, pml) ->
         if Assoc.mem s cx'.pm then
           check_valid_supertype (fst (Assoc.lookup s cx'.pm))
@@ -1336,6 +1339,14 @@ and check_exprog (tl : prog) (cx : contexts) : contexts * TypedAst.prog =
       (cx, []) tl in
   (cx', List.rev f)
 
+let print_term_linenumbers (tl: prog) : unit =
+  debug_print ">> print_term_linenumbers";
+  List.iter
+  (fun ((t, meta) : aterm) ->
+    debug_print (string_of_term t);
+    debug_print (string_of_int (meta.pos_lnum))
+  ) tl
+
 let rec check_term_list (tl : prog) (externs : prog Assoc.context) :
     contexts * TypedAst.prog =
   debug_print ">> check_global_var_or_fn_lst" ;
@@ -1352,6 +1363,7 @@ let rec check_term_list (tl : prog) (externs : prog Assoc.context) :
 (* Returns the list of fn's which represent the program
  * and params of the void main() fn *)
 let check_prog (tl : prog) (externs : prog Assoc.context) : TypedAst.prog =
+  print_term_linenumbers tl;
   debug_print ">> check_prog" ;
   let cx, typed_prog = check_term_list tl externs in
   check_main_fn cx ;

--- a/src/check.ml
+++ b/src/check.ml
@@ -1362,31 +1362,9 @@ and check_exprog (tl : prog) (cx : contexts) : contexts * TypedAst.prog =
       (cx, []) tl in
   (cx', List.rev f)
 
-let print_term_linenumbers (tl: prog) : unit =
-  debug_print ">> print_term_linenumbers";
-  List.iter
-  (fun ((t, meta) : aterm) ->
-    debug_print (string_of_term t);
-    debug_print (string_of_int (meta.pos_lnum))
-  ) tl
-
-let rec check_term_list (tl : prog) (externs : prog Assoc.context) :
-    contexts * TypedAst.prog =
-  debug_print ">> check_global_var_or_fn_lst" ;
-  (* Annoying bootstrapping hack *)
-  let cx, f =
-    List.fold_left
-      (fun acc t ->
-        let cx', f' = check_aterm (fst acc) t in
-        (cx', (snd acc) @ f'))
-      (init (snd (List.hd tl)) externs, [])
-      tl in
-  (cx, f)
-
 (* Returns the list of fn's which represent the program
  * and params of the void main() fn *)
 let check_prog (tl : prog) (externs : prog Assoc.context) : TypedAst.prog =
-  print_term_linenumbers tl;
   debug_print ">> check_prog" ;
   let cx, typed_prog = check_term_list tl externs in
   check_main_fn cx ;

--- a/src/check.ml
+++ b/src/check.ml
@@ -1362,6 +1362,19 @@ and check_exprog (tl : prog) (cx : contexts) : contexts * TypedAst.prog =
       (cx, []) tl in
   (cx', List.rev f)
 
+let rec check_term_list (tl : prog) (externs : prog Assoc.context) :
+    contexts * TypedAst.prog =
+  debug_print ">> check_global_var_or_fn_lst" ;
+  (* Annoying bootstrapping hack *)
+  let cx, f =
+    List.fold_left
+      (fun acc t ->
+        let cx', f' = check_aterm (fst acc) t in
+        (cx', (snd acc) @ f'))
+      (init (snd (List.hd tl)) externs, [])
+      tl in
+  (cx, f)
+
 (* Returns the list of fn's which represent the program
  * and params of the void main() fn *)
 let check_prog (tl : prog) (externs : prog Assoc.context) : TypedAst.prog =

--- a/src/check.ml
+++ b/src/check.ml
@@ -1053,20 +1053,17 @@ let rec check_valid_supertype (cx : contexts) (cx' : contexts) (t : typ) : typ =
         | Some d -> ()
         | None -> error cx ("Bad type declaration: Invalid frame " ^ s))
       | _ -> error cx ("Bad type declaration: Invalid frame " ^ (string_of_typ frame_typ)) in
-      (*let new_cx = with_scheme cx' TODO in*)
-      let tpm_object = match get_typ_safe cx' s2 with
+      let tpm_object = match get_typ_safe cx' (s1 ^ "." ^ s2) with
       | Some (_, tpm', _) -> tpm'
       | None -> error cx ("Bad type declaration: Invalid object " ^ s2) in
       check_valid_supertype_helper cx cx' false s1 t pml1 tpm_scheme;
-      check_valid_supertype_helper cx cx' false s2 t pml1 tpm_object;
+      check_valid_supertype_helper cx cx' false s2 t pml2 tpm_object;
       t
   | ParTyp (s, pml) ->
       if Assoc.mem s cx'.pm then
         check_valid_supertype cx cx' (fst (Assoc.lookup s cx'.pm)) 
       else
-        let tpm = match get_typ_safe cx' s with
-        | Some (_, tpm', _) -> tpm'
-        | None -> error cx ("5Bad type declaration: " ^ string_of_typ t) in
+        let (_, tpm, _) = get_typ cx' s in
         check_valid_supertype_helper cx cx' false s t pml tpm;
         t
   | _ -> error cx ("Invalid type declaration " ^ string_of_typ t)

--- a/src/checkUtil.ml
+++ b/src/checkUtil.ml
@@ -269,10 +269,16 @@ let get_canonical_vars (cx : contexts) : string list =
     (Assoc.bindings cx._bindings.g)
     []
 
+let get_frame_safe (cx : contexts) (id : string) : delta option =
+  match find_typ cx id with Some (Delta d) -> Some d | _ -> None
+
 let get_frame (cx : contexts) (x : string) : delta =
-  match find_typ cx x with
-  | Some (Delta d) -> d
+  match get_frame_safe cx x with
+  | Some d -> d
   | _ -> error cx ("Undefined frame " ^ x)
+
+let get_scheme_safe (cx : contexts) (id : string) : chi option =
+  match find_typ cx id with Some (Chi c) -> Some c | _ -> None
 
 let get_scheme (cx : contexts) (x : string) : chi =
   match find_typ cx x with

--- a/test/types/subtype_of_parameterized.lgl
+++ b/test/types/subtype_of_parameterized.lgl
@@ -1,0 +1,4 @@
+using "../glsl_defs.lgl";
+
+frame model has dimension 3;
+type m_pt is cart3<model>.point;

--- a/test/types/subtype_of_parameterized.lgl
+++ b/test/types/subtype_of_parameterized.lgl
@@ -1,14 +1,25 @@
 prototype geometry {
   object point;
+  with frame() r: object transformation;
 }
+
 with frame(3) r:
 coordinate cart3 : geometry {
   object point is float[3];
-}frame model has dimension 3;
+  with frame(2) f: object transformation is float[3][3];
+}
+
+frame model has dimension 3;
+frame world has dimension 3;
+
 type m_pt is cart3<model>.point;
+type m2w is cart3<model>.transformation<world>;
 
 m_pt foo(m_pt x) {
   return x;
 }
 
 
+m2w bar(m2w x) {
+  return x;
+}

--- a/test/types/subtype_of_parameterized.lgl
+++ b/test/types/subtype_of_parameterized.lgl
@@ -1,4 +1,8 @@
-using "../glsl_defs.lgl";
-
-frame model has dimension 3;
+prototype geometry {
+  object point;
+}
+with frame(3) r:
+coordinate cart3 : geometry {
+  object point is float[3];
+}frame model has dimension 3;
 type m_pt is cart3<model>.point;

--- a/test/types/subtype_of_parameterized.lgl
+++ b/test/types/subtype_of_parameterized.lgl
@@ -6,3 +6,9 @@ coordinate cart3 : geometry {
   object point is float[3];
 }frame model has dimension 3;
 type m_pt is cart3<model>.point;
+
+m_pt foo(m_pt x) {
+  return x;
+}
+
+


### PR DESCRIPTION
This should allow the creation of a subtype of a parameterized type such as cart3<model>.point

I still need to update the context for the "point" type in the above example so that the geometry prototype is visible.